### PR TITLE
fix that lets /dyn_cacherefresh work like intended now

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This is easily done. Go to your **server** folder and open *GameData/Tracks/Chal
 
 When adding and removing tracks, run */dyn_cacherefresh* ingame for changes to take effect.
 
-Important: You should only have 1 track in your real matchsettings, normally saved at */MatchSettings/tracklist.txt*. This plugin doesn't change anything there, it's just to get the server started. It would complain if there was no track at all.
+Important: You should only have 1 track in your real matchsettings, normally saved at */MatchSettings/tracklist.txt*. This plugin doesn't change anything there, it's just to get the server started. It would complain if there was no track at all. The track added this tracklist should be in the *dynmaps* folder mentioned above.
 
 
 ## Chatcommands

--- a/xaseco/includes/rasp.funcs.php
+++ b/xaseco/includes/rasp.funcs.php
@@ -73,14 +73,12 @@ function getChallengesCache($aseco, $reload = false) {
 		$aseco->client->resetError();
 		$newlist = array();
 		$done = false;
-		$size = 100;
-		$i = 0;
 		
 		// $aseco->client->query('GetChallengeList', $size, $i); Don't get it from server, emulate it instead
 		if ($reload) {
 			// Get challenges list from folder and fetch infos
 			// might take up to a minute (tested with 10k maps, ~1.5 minutes)
-			$tracks = $dyn->emulateGetChallengeList($dyn->maps, $size, $i);
+			$tracks = $dyn->emulateGetChallengeList($dyn->maps);
 		} else {
 			// don't reload, return the cache
 			return $challengeListCache;

--- a/xaseco/includes/rasp.funcs.php
+++ b/xaseco/includes/rasp.funcs.php
@@ -78,7 +78,7 @@ function getChallengesCache($aseco, $reload = false) {
 		if ($reload) {
 			// Get challenges list from folder and fetch infos
 			// might take up to a minute (tested with 10k maps, ~1.5 minutes)
-			$tracks = $dyn->emulateGetChallengeList($dyn->maps);
+			$tracks = $dyn->emulateGetChallengeList();
 		} else {
 			// don't reload, return the cache
 			return $challengeListCache;

--- a/xaseco/plugins/askuri.dynmaps.php
+++ b/xaseco/plugins/askuri.dynmaps.php
@@ -74,7 +74,7 @@ class dyn {
 		$this->aseco->client->query('GetTracksDirectory');
 		$this->mapdir = $aseco->server->trackdir;
 		// Get available maps for buffering
-		$this->maps = glob($this->mapdir.'Challenges/dynmaps/*.Challenge.Gbx');
+		$this->maps = glob($this->mapdir.'Challenges/dynmaps/*.[Cc]hallenge.[Gg]bx');
 		// $this->currmap_glob_id = 1;
 		
 		// shuffling the tracklist to avoid alphabetic ordering of tracks and playing same tracks upon server restart
@@ -154,17 +154,16 @@ class dyn {
 	}
 	
 	// used by rasp.funcs.php. Emulates a "GetChallengeList" request to dedicated server
-	public function emulateGetChallengeList($maps) {
+	public function emulateGetChallengeList() {
 		
-		$list = glob($this->mapdir.'Challenges/dynmaps/*.Challenge.Gbx');
+		$tracks = glob($this->mapdir.'Challenges/dynmaps/*.[Cc]hallenge.[Gg]bx');
 		
-		// shuffle the list for having a well mixed tracklist, not an alphabetically ordered tracklist
-		shuffle($list);
+		$list = [];
 		
 		$i = 0;
 		$errors = array();
 		$gbx = new GBXChallMapFetcher();
-		foreach ($list as $path) {
+		foreach ($tracks as $path) {
 			$pos = strpos(str_replace('\\', '/', $path), '/GameData/Tracks/'); // replace \ to / and find position of tracks folder
 			$filename = substr($path, $pos+17); //cut 17 chars (length of path above) after finding
 			
@@ -192,6 +191,9 @@ class dyn {
 		
 		echo '.';
 		
+		// shuffle the list for having a well mixed tracklist, not an alphabetically ordered tracklist
+		shuffle($list);		
+
 		return $list;
 	}
 }

--- a/xaseco/plugins/askuri.dynmaps.php
+++ b/xaseco/plugins/askuri.dynmaps.php
@@ -9,7 +9,7 @@
  * ----------------------------------------------------------------------------------
  * Author:			askuri
  * E-Mail:			enwi2@t-online.de
- * Contributors:	dasschaf/timmy
+ * Contributors:	-
  * Version:			0.1.0
  * Date:			2013-09-18
  * Copyright:		2013 by askuri
@@ -77,8 +77,7 @@ class dyn {
 		$this->maps = glob($this->mapdir.'Challenges/dynmaps/*.Challenge.Gbx');
 		// $this->currmap_glob_id = 1;
 		
-		// shuffling the newly read tracklist in order to not have the same tracks played all over when restarting the server & aseco
-		// also avoids alphabetic ordering of the played tracks
+		// shuffling the tracklist to avoid alphabetic ordering of tracks and playing same tracks upon server restart
 		shuffle($this->maps);
 		
 		$this->bufferMaps();

--- a/xaseco/plugins/askuri.dynmaps.php
+++ b/xaseco/plugins/askuri.dynmaps.php
@@ -9,7 +9,7 @@
  * ----------------------------------------------------------------------------------
  * Author:			askuri
  * E-Mail:			enwi2@t-online.de
- * Contributors:	-
+ * Contributors:	dasschaf/timmy
  * Version:			0.1.0
  * Date:			2013-09-18
  * Copyright:		2013 by askuri
@@ -76,6 +76,10 @@ class dyn {
 		// Get available maps for buffering
 		$this->maps = glob($this->mapdir.'Challenges/dynmaps/*.Challenge.Gbx');
 		// $this->currmap_glob_id = 1;
+		
+		// shuffling the newly read tracklist in order to not have the same tracks played all over when restarting the server & aseco
+		// also avoids alphabetic ordering of the played tracks
+		shuffle($this->maps);
 		
 		$this->bufferMaps();
 	}
@@ -153,7 +157,11 @@ class dyn {
 	// used by rasp.funcs.php. Emulates a "GetChallengeList" request to dedicated server
 	public function emulateGetChallengeList($maps) {
 		
-		$list = glob($this->mapdir.'Challenges/dynmaps/*.Challenge.Gbx');	
+		$list = glob($this->mapdir.'Challenges/dynmaps/*.Challenge.Gbx');
+		
+		// shuffle the list for having a well mixed tracklist, not an alphabetically ordered tracklist
+		shuffle($list);
+		
 		$i = 0;
 		$errors = array();
 		$gbx = new GBXChallMapFetcher();

--- a/xaseco/plugins/askuri.dynmaps.php
+++ b/xaseco/plugins/askuri.dynmaps.php
@@ -151,14 +151,13 @@ class dyn {
 	}
 	
 	// used by rasp.funcs.php. Emulates a "GetChallengeList" request to dedicated server
-	public function emulateGetChallengeList($maps, $size, $i) {
-		$slice = array_slice($maps, $i, $size);
+	public function emulateGetChallengeList($maps) {
 		
-		$list = array();
+		$list = glob($this->mapdir.'Challenges/dynmaps/*.Challenge.Gbx');	
 		$i = 0;
 		$errors = array();
 		$gbx = new GBXChallMapFetcher();
-		foreach ($slice as $path) {
+		foreach ($list as $path) {
 			$pos = strpos(str_replace('\\', '/', $path), '/GameData/Tracks/'); // replace \ to / and find position of tracks folder
 			$filename = substr($path, $pos+17); //cut 17 chars (length of path above) after finding
 			


### PR DESCRIPTION
- fixed the plugin file - $dyn->emulateGetChallengeList() now needs no argument anymore and reads the tracks from the folder every time it's called (so every time /dyn_cacherefresh is called from chat) - this fixes issue #4 

other things:
- added to the readme that the one track in it should be from the dynmaps folder
- fixed the plugin file - allow challenge maps with miscapitalized file endings to be read
- track cache has no fixed size anymore caused by the $size variable in rasp.funcs.php, will be as large as the number of tracks in the directory