### PR TITLE
shuffling cache now depending on settings

### DIFF
--- a/xaseco/dynmaps.xml
+++ b/xaseco/dynmaps.xml
@@ -8,4 +8,8 @@
 	<!-- Collecting all information can take more than a minute! -->
 	<!-- If false, the last saved cache will be taken -->
 	<startup_cache_reload>false</startup_cache_reload>
+
+	<!-- Shuffle the tracks upon refreshing challenge cache and on startup -->
+	<!-- useful feature to prevent an alphabetic order of tracks or when the same tracks get played over and over on server startup -->
+	<shuffle_cache>true</shuffle_cache>
 </dynmaps>

--- a/xaseco/plugins/askuri.dynmaps.php
+++ b/xaseco/plugins/askuri.dynmaps.php
@@ -78,7 +78,11 @@ class dyn {
 		// $this->currmap_glob_id = 1;
 		
 		// shuffling the tracklist to avoid alphabetic ordering of tracks and playing same tracks upon server restart
-		shuffle($this->maps);
+		// shuffling based on settings!
+		if ($this->settings->shuffle_cache[0] == 'true')
+		{
+			shuffle($this->maps);
+		}
 		
 		$this->bufferMaps();
 	}
@@ -191,8 +195,12 @@ class dyn {
 		
 		echo '.';
 		
-		// shuffle the list for having a well mixed tracklist, not an alphabetically ordered tracklist
-		shuffle($list);		
+		// shuffling the tracklist to avoid alphabetic ordering of tracks and playing same tracks upon server restart
+		// shuffling based on settings!
+		if ($this->settings->shuffle_cache[0] == 'true')
+		{
+			shuffle($list);
+		}	
 
 		return $list;
 	}


### PR DESCRIPTION
As suggested, shuffling the cache upon reload or generation will depend on whether the new setting in the dynmaps.xml file is true or false.