### PR TITLE
fix(emulateGetChallengeList): don't miss files that start with a dot

### DIFF
--- a/xaseco/plugins/askuri.dynmaps.php
+++ b/xaseco/plugins/askuri.dynmaps.php
@@ -160,7 +160,10 @@ class dyn {
 	// used by rasp.funcs.php. Emulates a "GetChallengeList" request to dedicated server
 	public function emulateGetChallengeList() {
 		
-		$tracks = glob($this->mapdir.'Challenges/dynmaps/*.[Cc]hallenge.[Gg]bx');
+		$tracks = array_merge(
+			glob($this->mapdir.'Challenges/dynmaps/*.[Cc]hallenge.[Gg]bx'),
+			glob($this->mapdir.'Challenges/dynmaps/.*.[Cc]hallenge.[Gg]bx')
+		);
 		
 		$list = [];
 		

--- a/xaseco/plugins/askuri.dynmaps.php
+++ b/xaseco/plugins/askuri.dynmaps.php
@@ -160,6 +160,8 @@ class dyn {
 	// used by rasp.funcs.php. Emulates a "GetChallengeList" request to dedicated server
 	public function emulateGetChallengeList() {
 		
+		// glob ignores files with a dot-prefix (hidden filles on unix like systems) by default.
+		// That's why we run glob once more explicitly looking for hidden files.
 		$tracks = array_merge(
 			glob($this->mapdir.'Challenges/dynmaps/*.[Cc]hallenge.[Gg]bx'),
 			glob($this->mapdir.'Challenges/dynmaps/.*.[Cc]hallenge.[Gg]bx')


### PR DESCRIPTION
Not sure about windows, but in unix these are hidden files, and PHP `glob` would ignore them unless asked explicitly